### PR TITLE
移除SSL认证

### DIFF
--- a/QQ.py
+++ b/QQ.py
@@ -8,6 +8,7 @@ import os
 import time
 import logging
 import traceback
+from requests.packages import urllib3
 from flask import Flask,request
 from datetime import datetime
 
@@ -318,6 +319,7 @@ async def recvMsg():
 
 
 if __name__ == '__main__':
+    urllib3.disable_warnings()
     errorlog_clean = open(str((os.path.split(os.path.realpath(__file__))[0]).replace('\\', '/')) + '/error.log', 'w').close()
     prt('程序开始运行')
     app.run(host="127.0.0.1",port=5000)

--- a/QQ.py
+++ b/QQ.py
@@ -186,7 +186,7 @@ def getfriendmark(UID):
 def data_send(url, **kwargs):
     for i in range(1, 5):
         try:
-            response = requests.post(url, data=kwargs, timeout=5)
+            response = requests.post(url, data=kwargs, timeout=5, verify=False)
             if response.status_code > 299:
                 raise RuntimeError
         except:


### PR DESCRIPTION
无伤大雅，但为了解决可能存在的接口证书过期/自建接口没有证书等问题，还是建议移除